### PR TITLE
Rebrand branch children --> subcommands

### DIFF
--- a/examples/.vscode/settings.json
+++ b/examples/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "cSpell.words": [
     "subcommand",
-    "children"
+    "subcommands"
   ]
 }

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@carnesen/cli-examples",
-  "version": "0.5.0-17",
+  "version": "0.5.0-18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -437,9 +437,9 @@
       "dev": true
     },
     "@carnesen/cli": {
-      "version": "0.5.0-17",
-      "resolved": "https://registry.npmjs.org/@carnesen/cli/-/cli-0.5.0-17.tgz",
-      "integrity": "sha512-EUKEcLNs+RnhMwF8f4sDL/s/Xd4nQKrkc1FXFnJTP7ZgtN6m3p8lPT+DkbRbV1Pjv/U9wZQA/Q5JPs1e8+XFiA=="
+      "version": "0.5.0-18",
+      "resolved": "https://registry.npmjs.org/@carnesen/cli/-/cli-0.5.0-18.tgz",
+      "integrity": "sha512-xoEDFFk6+nbHJffrBr6iprFg0peYEwVd2mp9foisE1vu5pRGICXdSTu6ywa+QIZJLp9vV351Hic/q7nV79193A=="
     },
     "@carnesen/run-and-catch": {
       "version": "0.4.0",

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carnesen/cli-examples",
   "description": "Examples of how to use @carnesen/cli",
-  "version": "0.5.0-17",
+  "version": "0.5.0-18",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "bin": {
@@ -20,7 +20,7 @@
     "prepublishOnly": "npm test"
   },
   "dependencies": {
-    "@carnesen/cli": "0.5.0-17"
+    "@carnesen/cli": "0.5.0-18"
   },
   "devDependencies": {
     "@carnesen/run-and-catch": "0.4.0",

--- a/examples/src/advanced/echo-as-hidden-command/index.ts
+++ b/examples/src/advanced/echo-as-hidden-command/index.ts
@@ -28,8 +28,8 @@ const branch = CliBranch({
 	description: `
 		Non-hidden command "${echoCommand.name}" shows up in this usage documentation.
 		
-		Hidden subcommand "${echoAsHiddenCommand.name}" does not appear in the children list.`,
-	children: [echoAsHiddenCommand, echoCommand],
+		Hidden subcommand "${echoAsHiddenCommand.name}" does not appear in the subcommands list.`,
+	subcommands: [echoAsHiddenCommand, echoCommand],
 });
 
 // Exported for unit testing

--- a/examples/src/advanced/hidden-branch/index.ts
+++ b/examples/src/advanced/hidden-branch/index.ts
@@ -6,7 +6,7 @@ const normalBranch = CliBranch({
 	description: `
     This is a normal non-hidden command branch.
     Its "description" shows up in command usage docs.`,
-	children: [echo],
+	subcommands: [echo],
 });
 
 // Exported for unit testing
@@ -16,16 +16,16 @@ export const hiddenBranch = CliBranch({
 	name: HIDDEN_BRANCH,
 	description: `
     This is a command branch that has hidden=true.
-    It does not show up in the list of "children",
+    It does not show up in the list of "subcommands",
     but it is otherwise fully functional.`,
 	hidden: true,
-	children: [echo],
+	subcommands: [echo],
 });
 
 const branch = CliBranch({
 	name: 'cli',
 	description: `This CLI has a hidden branch called "${HIDDEN_BRANCH}.`,
-	children: [normalBranch, hiddenBranch],
+	subcommands: [normalBranch, hiddenBranch],
 });
 
 // Exported for unit testing

--- a/examples/src/advanced/index.ts
+++ b/examples/src/advanced/index.ts
@@ -10,7 +10,7 @@ export const advanced = CliBranch({
 	Examples of advanced @carnesen/cli features. This is a hidden branch!
 	`,
 	hidden: true,
-	children: [
+	subcommands: [
 		demoEscapedArguments,
 		echoWithHiddenOption,
 		echoAsHiddenCommand,

--- a/examples/src/index.ts
+++ b/examples/src/index.ts
@@ -9,5 +9,5 @@ export const root = CliBranch({
 	description: `
 	Examples that demonstrate @carnesen/cli features
 	`,
-	children: [echo, multiply, throwError, advanced],
+	subcommands: [echo, multiply, throwError, advanced],
 });

--- a/main/package-lock.json
+++ b/main/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@carnesen/cli",
-  "version": "0.5.0-17",
+  "version": "0.5.0-18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/main/package.json
+++ b/main/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carnesen/cli",
   "description": "A framework for command-line interfaces in Node.js and the browser",
-  "version": "0.5.0-17",
+  "version": "0.5.0-18",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {

--- a/main/src/cli-branch.ts
+++ b/main/src/cli-branch.ts
@@ -15,7 +15,7 @@ export interface ICliBranchOptions {
 	hidden?: boolean;
 
 	/** [[`ICliBranch`]] and/or [[`ICliCommand`]]s underneath this branch */
-	children: (ICliBranch | ICliCommand<any, any, any>)[];
+	subcommands: (ICliBranch | ICliCommand<any, any, any>)[];
 }
 
 /**

--- a/main/src/cli-tree.ts
+++ b/main/src/cli-tree.ts
@@ -5,17 +5,9 @@ import { ICliArgGroup } from './cli-arg-group';
 /**
  * The root of a command tree
  */
-export type TCliRoot<
-	TPositionalArgGroup extends ICliArgGroup = ICliArgGroup,
-	TNamedArgGroups extends {
-		[name: string]: ICliArgGroup;
-	} = {
-		[name: string]: ICliArgGroup;
-	},
-	TEscapedArgGroup extends ICliArgGroup = ICliArgGroup
-> =
+export type TCliRoot =
 	| ICliBranch
-	| ICliCommand<TPositionalArgGroup, TNamedArgGroups, TEscapedArgGroup>;
+	| ICliCommand<ICliArgGroup, any, ICliArgGroup>;
 
 /**
  * A node in a command tree

--- a/main/src/cli.test.ts
+++ b/main/src/cli.test.ts
@@ -38,7 +38,7 @@ const commandWithEscapedArgGroup = CliCommand({
 
 const root = CliBranch({
 	name: 'cli',
-	children: [
+	subcommands: [
 		commandWithNoArguments,
 		commandWithPositionalArgGroup,
 		commandWithNamedArgGroups,

--- a/main/src/cli.ts
+++ b/main/src/cli.ts
@@ -24,7 +24,7 @@ export interface ICli {
  *
  * @param root The root of this command-line interface's command tree
  */
-export function Cli(root: TCliRoot<any, any, any>): ICli {
+export function Cli(root: TCliRoot): ICli {
 	return async function cli(...args: string[]) {
 		const node = findCliNode(root, args);
 

--- a/main/src/find-cli-node.test.ts
+++ b/main/src/find-cli-node.test.ts
@@ -12,7 +12,7 @@ const command = CliCommand({
 
 const branch = CliBranch({
 	name: 'cli',
-	children: [command],
+	subcommands: [command],
 });
 
 describe(findCliNode.name, () => {

--- a/main/src/find-cli-node.ts
+++ b/main/src/find-cli-node.ts
@@ -43,7 +43,7 @@ function recursiveFindCliNode(result: IFindCliNodeResult): IFindCliNodeResult {
 			return result;
 		}
 
-		const next = result.current.children.find(
+		const next = result.current.subcommands.find(
 			(subcommand) => subcommand.name === result.args[0],
 		);
 

--- a/main/src/usage-string.test.ts
+++ b/main/src/usage-string.test.ts
@@ -31,7 +31,7 @@ const current = CliCommand({
 const branch = CliBranch({
 	name: 'cli',
 	description: 'This is a CLI',
-	children: [current],
+	subcommands: [current],
 });
 
 describe(UsageString.name, () => {

--- a/main/src/usage-subcommand-rows.test.ts
+++ b/main/src/usage-subcommand-rows.test.ts
@@ -15,8 +15,11 @@ const hiddenCommand = CliCommand({
 	action() {},
 });
 
-const branch = CliBranch({ name: 'users', children: [command, hiddenCommand] });
-const root = CliBranch({ name: 'cloud', children: [branch] });
+const branch = CliBranch({
+	name: 'users',
+	subcommands: [command, hiddenCommand],
+});
+const root = CliBranch({ name: 'cloud', subcommands: [branch] });
 
 describe(UsageSubcommandRows.name, () => {
 	it('lists all commands underneath the provided branch, recursive', () => {

--- a/main/src/usage-subcommand-rows.ts
+++ b/main/src/usage-subcommand-rows.ts
@@ -25,11 +25,11 @@ function RecursiveUsageSubcommandRows(
 
 	if (current.kind === CLI_BRANCH) {
 		const subcommandsForUsage: TwoColumnTableRow[] = [];
-		for (const child of current.children) {
+		for (const subcommand of current.subcommands) {
 			subcommandsForUsage.push(
 				...RecursiveUsageSubcommandRows(
-					child,
-					path ? `${path} ${child.name}` : child.name,
+					subcommand,
+					path ? `${path} ${subcommand.name}` : subcommand.name,
 				),
 			);
 		}


### PR DESCRIPTION
Subcommand is the word we use in command-line usage. Let's be consistent
and use that in the library's API too.

Release 0.5.0-17
