### PR TITLE
0.5.0

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@carnesen/cli-examples",
-	"version": "0.5.0-26",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@carnesen/cli-examples",
 	"description": "Examples of how to use @carnesen/cli",
-	"version": "0.5.0-26",
+	"version": "0.5.0",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
 	"bin": {

--- a/main/changelog.md
+++ b/main/changelog.md
@@ -1,19 +1,22 @@
 # **@carnesen/cli** changelog
 
-## 0.5.0 - Unreleased
+## 0.5.0 - 2020-09-12
 
 ### Breaking
+
 We completely overhauled the API in this release with the goal of making it as easy as possible to understand and use, but also with an eye on achieving 100% backwards compatibility by 1.0.
 
 A user of v0.3 would scarcely recognize this library's public API, but they'd be in luck because now it's 100% documented both in the source code and online. If you were an early adopter of **@carnesen/cli**, thank you! We'd be happy to help you upgrade to 0.5, just [file an issue on this project's repository on GitHub](https://github.com/carnesen/cli/issues/new) asking for assistance.
 
 ### Features
+
 - Browser compatibility: We've removed all runtime dependencies on third-party packages and Node.js-specific global variables like `process`, nor do we depend on `@types/node` (except internally for unit tests) nor the `DOM` TypeScript lib.
-- API docs built from source using TypeDoc, published as the npm package `@carnesen/cli-docs` and on the web at [https://cli.carnesen.com](https://cli.carnesen.com)
-- Re-wrap the argument/branch/command description text to fit the user's terminal in command-line usage
+- API docs built from source using TypeDoc, published as the npm package `@carnesen/cli-docs` and on the web at [https://cli.carnesen.com/docs](https://cli.carnesen.com/docs)
+- Fold the argument/branch/command description text to fit the user's terminal in command-line usage
 - Built-in ANSI text decoration in `description` and `action`
 
 ### Other
+
 - Split out the examples into a separate top-level sub-directory `examples` in the `carnesen/cli` monorepo and publish as separate package `@carnesen/cli-examples`.
 
 ## 0.4.0 - 2020-05-15

--- a/main/package.json
+++ b/main/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@carnesen/cli",
 	"description": "A command-line interface framework for Node.js and web browser",
-	"version": "0.5.0-26",
+	"version": "0.5.0",
 	"main": "lib/index.js",
 	"types": "lib/index.d.ts",
 	"engines": {

--- a/website-server/package-lock.json
+++ b/website-server/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@carnesen/cli-website-server",
-	"version": "2020.9.0",
+	"version": "2020.9.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -466,14 +466,14 @@
 			"dev": true
 		},
 		"@carnesen/cli-docs": {
-			"version": "0.5.0-26",
-			"resolved": "https://registry.npmjs.org/@carnesen/cli-docs/-/cli-docs-0.5.0-26.tgz",
-			"integrity": "sha512-SrKySPDLwlSjPZqXhGwuud9mpmY7YpErux7W4bpzNMU1RKM72PGawxSAACs6HMy/i2TXCCEkcdYX7UigUEJ8Iw=="
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@carnesen/cli-docs/-/cli-docs-0.5.0.tgz",
+			"integrity": "sha512-zM/ypAGdQEOsVB67x9mf1CF/dG05CP2TodA1zd6EXj3UrCw9o8EhggiSyFQRY9afKvrq0N9yhC8GGKE+Egnf7w=="
 		},
 		"@carnesen/cli-website": {
-			"version": "2020.9.0",
-			"resolved": "https://registry.npmjs.org/@carnesen/cli-website/-/cli-website-2020.9.0.tgz",
-			"integrity": "sha512-O7eTwyptq8CcL5l440mgTKFYcLxuQSwMXxPSP7Ji0dW9PjEwvnLhp0/QS66QtRtcmDg3aQWZvxKlQMCpWDZIDA=="
+			"version": "2020.9.1",
+			"resolved": "https://registry.npmjs.org/@carnesen/cli-website/-/cli-website-2020.9.1.tgz",
+			"integrity": "sha512-tIeBOXjBiuRUlL7gIpxtFOBwnkEJWQnHTI9+WN3jZU1VOpnYuQDKlzMEQVpO3Cr6x2dIX3tYuvnYWeq5EYqw5g=="
 		},
 		"@carnesen/tsconfig": {
 			"version": "0.4.0",

--- a/website-server/package.json
+++ b/website-server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@carnesen/cli-website-server",
 	"description": "Node.js server for cli.carnesen.com",
-	"version": "2020.9.0",
+	"version": "2020.9.1",
 	"engines": {
 		"node": ">=12.0.0"
 	},
@@ -16,8 +16,8 @@
 		"prepublishOnly": "npm run test"
 	},
 	"dependencies": {
-		"@carnesen/cli-docs": "0.5.0-26",
-		"@carnesen/cli-website": "2020.9.0",
+		"@carnesen/cli-docs": "0.5.0",
+		"@carnesen/cli-website": "2020.9.1",
 		"@types/koa-mount": "4.0.0",
 		"http-status-codes": "1.4.0",
 		"koa": "2.13.0",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@carnesen/cli-website",
-	"version": "2020.9.0",
+	"version": "2020.9.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -417,18 +417,26 @@
 			"dev": true
 		},
 		"@carnesen/cli": {
-			"version": "0.5.0-26",
-			"resolved": "https://registry.npmjs.org/@carnesen/cli/-/cli-0.5.0-26.tgz",
-			"integrity": "sha512-rPtZTFSgWMkqpa98efcjl4tMvSW7N3F+F7WkGoV2B5LTen6ETAbYnEtr7poygotWVKGQyyKKq9xURN1q5A4XdA==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@carnesen/cli/-/cli-0.5.0.tgz",
+			"integrity": "sha512-lu57Ef/+DBVe8ldAoB2QjId1fA/DL0s5PUTIhiCNfr0J+UHhPpeE1fgecM3r4wbVB3yl69GvPNHYqtzZaCtoEg==",
 			"dev": true
 		},
 		"@carnesen/cli-examples": {
-			"version": "0.5.0-26",
-			"resolved": "https://registry.npmjs.org/@carnesen/cli-examples/-/cli-examples-0.5.0-26.tgz",
-			"integrity": "sha512-+2laCufVuac2EgQ5xxmMmDXz9PBUPP5JdYtmSPMTDz5+1D1IlKOrxLWnAR0Zh9ZgG5D/K7A7sFYmk9QBsv2mxA==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@carnesen/cli-examples/-/cli-examples-0.5.0.tgz",
+			"integrity": "sha512-svAsSYNVN2VSgd9QHxziG7BR5QAjmaIyvBmFgbBXElEpGNpiqoa3P0f7wXELFdrYwVY4WcqPBKrjir3nVtwLUg==",
 			"dev": true,
 			"requires": {
 				"@carnesen/cli": "0.5.0-26"
+			},
+			"dependencies": {
+				"@carnesen/cli": {
+					"version": "0.5.0-26",
+					"resolved": "https://registry.npmjs.org/@carnesen/cli/-/cli-0.5.0-26.tgz",
+					"integrity": "sha512-rPtZTFSgWMkqpa98efcjl4tMvSW7N3F+F7WkGoV2B5LTen6ETAbYnEtr7poygotWVKGQyyKKq9xURN1q5A4XdA==",
+					"dev": true
+				}
 			}
 		},
 		"@carnesen/run-and-catch": {

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@carnesen/cli-website",
 	"description": "Source and packaged site for https://cli.carnesen.com/",
-	"version": "2020.9.0",
+	"version": "2020.9.1",
 	"engines": {
 		"node": ">=12.0.0"
 	},
@@ -18,8 +18,8 @@
 	},
 	"dependencies": {},
 	"devDependencies": {
-		"@carnesen/cli": "0.5.0-26",
-		"@carnesen/cli-examples": "0.5.0-26",
+		"@carnesen/cli": "0.5.0",
+		"@carnesen/cli-examples": "0.5.0",
 		"@carnesen/run-and-catch": "0.4.0",
 		"@carnesen/tsconfig": "0.3.1",
 		"@types/jest": "26.0.4",

--- a/website/src/root-command-group.ts
+++ b/website/src/root-command-group.ts
@@ -22,7 +22,7 @@ export const rootCommandGroup = CliCommandGroup({
 		This is ${bold('@carnesen/cli')} examples running in your browser console.`,
 	subcommands: [
 		docsCommand,
-		echoCommand,
+		echoCommand as any,
 		multiplyCommand,
 		showCommand,
 		throwErrorCommand,


### PR DESCRIPTION
### Breaking

We completely overhauled the API in this release with the goal of making it as easy as possible to understand and use, but also with an eye on achieving 100% backwards compatibility by 1.0.

A user of v0.3 would scarcely recognize this library's public API, but they'd be in luck because now it's 100% documented both in the source code and online. If you were an early adopter of **@carnesen/cli**, thank you! We'd be happy to help you upgrade to 0.5, just [file an issue on this project's repository on GitHub](https://github.com/carnesen/cli/issues/new) asking for assistance.

### Features

- Browser compatibility: We've removed all runtime dependencies on third-party packages and Node.js-specific global variables like `process`, nor do we depend on `@types/node` (except internally for unit tests) nor the `DOM` TypeScript lib.
- API docs built from source using TypeDoc, published as the npm package `@carnesen/cli-docs` and on the web at [https://cli.carnesen.com/docs](https://cli.carnesen.com/docs)
- Fold the argument/branch/command description text to fit the user's terminal in command-line usage
- Built-in ANSI text decoration in `description` and `action`

### Other

- Split out the examples into a separate top-level sub-directory `examples` in the `carnesen/cli` monorepo and publish as separate package `@carnesen/cli-examples`.